### PR TITLE
Require Swift 6.2 and refresh docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   format:
-    name: Formatting (Swift 6)
+    name: Formatting (Swift 6.2)
     runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Select Xcode 26 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
       - name: Swift version
         run: swift --version
       - name: Formatting (lint)
@@ -25,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Select Xcode 26 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
       - name: Swift version
         run: swift --version
       - name: Build (debug)

--- a/.github/workflows/docc-generate.yml
+++ b/.github/workflows/docc-generate.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode 26 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
+
       - name: Generate DocC
         env:
           DOCS_DOMAIN: ${{ inputs.docs-domain }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@next
         with:
-          swift-version: "6.1"
+          swift-version: "6.2"
       
       - name: Build
         run: swift build -v
@@ -59,7 +59,7 @@ jobs:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-integration')
     strategy:
       matrix:
-        swift: ["6.1"]
+        swift: ["6.2"]
     steps:
       - uses: actions/checkout@v4
       
@@ -99,7 +99,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        swift: ["6.1"]
+        swift: ["6.2"]
     steps:
       - uses: actions/checkout@v4
       
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@next
         with:
-          swift-version: "6.1"
+          swift-version: "6.2"
       
       - name: Run Stress Tests
         run: |
@@ -183,7 +183,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@next
         with:
-          swift-version: "6.1"
+          swift-version: "6.2"
       
       - name: Build and Test
         run: |
@@ -199,7 +199,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@next
         with:
-          swift-version: "6.1"
+          swift-version: "6.2"
       
       - name: Run Performance Tests
         run: |
@@ -313,7 +313,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@next
         with:
-          swift-version: "6.1"
+          swift-version: "6.2"
       
       - name: Build Documentation
         run: |

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Select Xcode 26 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
+
       - name: Swift version
         run: swift --version
 
@@ -67,4 +72,3 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode 26 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
+
       - name: Swift version
         run: swift --version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ Unreleased
 ### Breaking Changes
 - Minimum supported Swift has been raised to 6.2 (requires Xcode 26+) to adopt the "Approachable Concurrency" defaults and stricter Sendable checking.
 
-### Documentation
+### Enhancements
 - Updated README, contributor guides, and DocC content to reference Swift 6.2 best practices and tooling.
+- Increased the default probe timeout to 2000 ms (`SwiftFTRConfig.maxWaitMs`) and adjusted CLI defaults accordingly.
+- Added `-v/--version` to the `swift-ftr` CLI and show extended help when no destination is provided.
 
 0.4.0 — 2025-09-15
 ------------------
@@ -111,7 +113,7 @@ Unreleased
   - All configuration now passed explicitly via `SwiftFTRConfig` initialization
 - **NEW**: Configuration-based API with `SwiftFTRConfig` struct
   - `maxHops`: Maximum TTL to probe (default: 30)
-  - `maxWaitMs`: Timeout in milliseconds (default: 1000)
+  - `maxWaitMs`: Timeout in milliseconds (default: 2000)
   - `payloadSize`: ICMP payload size in bytes (default: 56)
   - `publicIP`: Override public IP detection (optional)
   - `enableLogging`: Enable debug logging (default: false)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog
 
 All notable changes to this project are documented here. This project follows Semantic Versioning.
 
+Unreleased
+----------
+### Breaking Changes
+- Minimum supported Swift has been raised to 6.2 (requires Xcode 26+) to adopt the "Approachable Concurrency" defaults and stricter Sendable checking.
+
+### Documentation
+- Updated README, contributor guides, and DocC content to reference Swift 6.2 best practices and tooling.
+
 0.4.0 — 2025-09-15
 ------------------
 ### Major Features
@@ -90,14 +98,14 @@ All notable changes to this project are documented here. This project follows Se
 
 ### Compatibility
 - No breaking changes - fully backward compatible
-- Maintains Swift 6.1 strict concurrency compliance
+- Maintains Swift 6.2 strict concurrency compliance
 - All 44 tests passing
 
 0.2.0 — 2025-09-08
 -------------------
-- **BREAKING**: Minimum Swift version now 6.1 (was 5.10)
+- **BREAKING**: Minimum Swift version now 6.1 (was 5.10) *(superseded; project now targets Swift 6.2 in Unreleased section)*
   - Package now builds exclusively in Swift 6 language mode
-  - Requires Xcode 16.4 or later
+  - Requires Xcode 16.4 or later *(original baseline; current requirement is Xcode 26+)*
 - **BREAKING**: Removed all environment variable dependencies in favor of configuration API
   - Replaced `PTR_SKIP_STUN` and `PTR_PUBLIC_IP` with `SwiftFTRConfig` struct
   - All configuration now passed explicitly via `SwiftFTRConfig` initialization
@@ -112,7 +120,7 @@ All notable changes to this project are documented here. This project follows Se
   - `--payload-size`: Configure ICMP payload size
   - `--public-ip`: Override public IP (replaces PTR_PUBLIC_IP env var)
   - Removed `--no-stun` flag (now implied when `--public-ip` is set)
-- **NEW**: Swift 6.1 full compliance
+- **NEW**: Swift 6.2 full compliance
   - All types marked `Sendable`
   - All public methods marked `nonisolated`
   - Thread-safe without MainActor requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased
 ### Enhancements
 - Updated README, contributor guides, and DocC content to reference Swift 6.2 best practices and tooling.
 - Increased the default probe timeout to 2000 ms (`SwiftFTRConfig.maxWaitMs`) and adjusted CLI defaults accordingly.
-- Added `-v/--version` to the `swift-ftr` CLI and show extended help when no destination is provided.
+- Added `-v/--version` to the `swift-ftr` CLI, show extended help when no destination is provided, and made `-w/--timeout` accept milliseconds instead of seconds.
 
 0.4.0 — 2025-09-15
 ------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,11 @@ The codebase defines several protocols for extensibility:
 - `DNSResolver`: Alternative DNS resolution strategies
 - All public types conform to `Sendable` for Swift 6 concurrency
 
-## Swift 6 Compliance
+## Swift 6.2 Concurrency
 
-This project requires Swift 6.1+ and builds with strict concurrency checking enabled:
+This project requires Swift 6.2+ and follows Apple's "Approachable Concurrency" defaults:
 - Language mode: Swift 6 (`swiftLanguageModes: [.v6]` in Package.swift)
-- All public types are `Sendable`
-- No `@MainActor` requirements for library APIs
-- Thread-safe from any actor or task context
+- Upcoming features `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` stay enabled for every target.
+- CLI entry points build with `-default-isolation MainActor` so executor hops are explicit.
+- Synchronous helpers that may fan out work are marked `@concurrent` before being invoked in parallel contexts.
+- All public types remain `Sendable` and the library stays actor-agnostic (no imposed `@MainActor`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for your interest in improving SwiftFTR! This guide describes how to set up your environment, propose changes, and keep contributions consistent and easy to review.
 
 ## Quick Start
-- Requirements: macOS 13+, Xcode 16.4+ (Swift 6.1+), GitHub CLI (optional).
+- Requirements: macOS 13+, Xcode 26+ (Swift 6.2+), GitHub CLI (optional).
 - Build & test:
   ```bash
   swift build -c debug
@@ -26,7 +26,7 @@ Thanks for your interest in improving SwiftFTR! This guide describes how to set 
 4. Open a Pull Request. The CI will run format, build, tests, docs.
 
 ## Formatting
-- We enforce Swift formatting in CI using `swift format` (Swift 6 toolchain).
+- We enforce Swift formatting in CI using `swift format` (Swift 6.2 toolchain).
 - Locally, you can install the git pre‑push hook once:
   ```bash
   git config core.hooksPath .githooks
@@ -54,6 +54,12 @@ Thanks for your interest in improving SwiftFTR! This guide describes how to set 
 - Unit tests should not depend on network access. Use fakes/mocks.
 - For code paths that perform DNS/WHOIS/STUN, prefer injectable resolvers via configuration. Use `SwiftFTRConfig(publicIP: ...)` to bypass STUN in tests.
 - Add tests next to the code they exercise under `Tests/SwiftFTRTests`.
+
+## Concurrency Guidelines
+- Keep single-threaded entry points (CLI, integration harnesses) on the main actor via `-Xswiftc -default-isolation -Xswiftc MainActor` to honor Swift 6.2's default isolation recommendations.
+- Mark synchronous helpers that can execute in parallel with `@concurrent` so reviewers and the compiler understand intent before adding new async work.
+- The package manifest enables the `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` upcoming features; keep new code free of diagnostics under these stricter Sendable checks.
+- Skim the Swift team’s "[Swift 6.2 Released](https://www.swift.org/blog/swift-6.2-released/)" blog post when adding concurrency-heavy features—it captures the rationale behind these defaults.
 
 ## Commit Style
 - Conventional commits preferred:

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,11 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
+
+/// Apply Swift 6.2 "Approachable Concurrency" defaults to every target.
+let concurrencySettings: [SwiftSetting] = [
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("InferIsolatedConformances")
+]
 
 let package = Package(
     name: "SwiftFTR",
@@ -19,31 +25,52 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")
     ],
     targets: [
-        .target(name: "SwiftFTR", path: "Sources/SwiftFTR"),
+        .target(
+            name: "SwiftFTR",
+            path: "Sources/SwiftFTR",
+            swiftSettings: concurrencySettings
+        ),
         .executableTarget(
             name: "swift-ftr",
             dependencies: [
                 "SwiftFTR",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
-            path: "Sources/swift-ftr"
+            path: "Sources/swift-ftr",
+            swiftSettings: concurrencySettings
         ),
-        .executableTarget(name: "icmpfuzz", dependencies: ["SwiftFTR"]),
+        .executableTarget(
+            name: "icmpfuzz",
+            dependencies: ["SwiftFTR"],
+            swiftSettings: concurrencySettings
+        ),
         .executableTarget(
             name: "icmpfuzzer",
             dependencies: ["SwiftFTR"],
             swiftSettings: [
                 // On Linux, enable libFuzzer main and sanitizers. On macOS this flag is unsupported.
                 .unsafeFlags(["-sanitize=fuzzer,address,undefined", "-D", "WITH_LIBFUZZER"], .when(platforms: [.linux]))
-            ]
+            ] + concurrencySettings
         ),
-        .executableTarget(name: "genseeds"),
-        .executableTarget(name: "ptrtests", dependencies: ["SwiftFTR"]),
-        .executableTarget(name: "integrationtest", dependencies: ["SwiftFTR"]),
+        .executableTarget(
+            name: "genseeds",
+            swiftSettings: concurrencySettings
+        ),
+        .executableTarget(
+            name: "ptrtests",
+            dependencies: ["SwiftFTR"],
+            swiftSettings: concurrencySettings
+        ),
+        .executableTarget(
+            name: "integrationtest",
+            dependencies: ["SwiftFTR"],
+            swiftSettings: concurrencySettings
+        ),
         .testTarget(
             name: "SwiftFTRTests",
             dependencies: ["SwiftFTR"],
-            path: "Tests/SwiftFTRTests"
+            path: "Tests/SwiftFTRTests",
+            swiftSettings: concurrencySettings
         )
     ],
     // Swift 6 language mode with strict concurrency checking

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SwiftFTR
 
 [![CI](https://github.com/Network-Weather/SwiftFTR/actions/workflows/ci.yml/badge.svg)](https://github.com/Network-Weather/SwiftFTR/actions/workflows/ci.yml)
 [![Docs](https://github.com/Network-Weather/SwiftFTR/actions/workflows/docs.yml/badge.svg)](https://swiftftr.networkweather.com/)
-[![Swift 6.1](https://img.shields.io/badge/Swift-6.1-orange.svg)](https://swift.org)
+[![Swift 6.2](https://img.shields.io/badge/Swift-6.2-orange.svg)](https://swift.org)
 [![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-blue.svg)](https://developer.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -46,7 +46,7 @@ If you need even tighter runs, lower `timeout` (e.g., `0.5`) or cap `maxHops` (e
 
 - Requirements
 --------------
-- Swift 6.1+ (requires Xcode 16.4 or later)
+- Swift 6.2+ (requires Xcode 26 or later)
 - macOS 13+
 - IPv4 only at the moment (ICMPv4 Echo). On Linux, typical ICMP requires raw sockets (root/CAP_NET_RAW); SwiftFTR targets macOS’s ICMP datagram behavior.
 
@@ -64,13 +64,14 @@ Install (SwiftPM)
   ]
   ```
 
-Swift 6.1 Compliance
---------------------
-SwiftFTR is fully compliant with Swift 6.1 concurrency requirements:
-- ✅ All public value types are `Sendable`
-- ✅ API works without `@MainActor` requirements
-- ✅ Thread-safe usage from any actor or task
-- ✅ Builds under Swift 6 language mode with strict concurrency checks
+Swift 6.2 Concurrency Posture
+-----------------------------
+SwiftFTR follows the Swift 6.2 "Approachable Concurrency" guidance:
+- ✅ CLI and other single-threaded entry points opt into `-default-isolation MainActor`, keeping predictable executor hopping.
+- ✅ Synchronous helpers that can run in parallel are marked `@concurrent`, clarifying intent for the compiler and reviewers.
+- ✅ Every target builds in Swift 6 language mode with upcoming features `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` enabled, hardening Sendable and actor isolation checks.
+- ✅ All public APIs remain usable from any actor without additional `@MainActor` or global locking requirements.
+- 📚 See [Swift 6.2 Released](https://www.swift.org/blog/swift-6.2-released/) for the official "Approachable Concurrency" recommendations this project adheres to.
 
 New in v0.4.0
 -------------
@@ -200,7 +201,7 @@ Documentation
 Generate and view the docs:
 
 - Xcode: Product → Build Documentation (or use the Documentation sidebar).
-- SwiftPM plugin (Xcode 16.4+/Swift 6.1+):
+- SwiftPM plugin (Xcode 26+/Swift 6.2+):
   ```bash
   swift package --allow-writing-to-directory docc \
     generate-documentation --target SwiftFTR \

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ import SwiftFTR
 // Configure once, use everywhere
 let config = SwiftFTRConfig(
     maxHops: 30,        // Max TTL to probe
-    maxWaitMs: 1000,    // Timeout in milliseconds
+    maxWaitMs: 2000,    // Timeout in milliseconds
     payloadSize: 56,    // ICMP payload size
     publicIP: nil,      // Auto-detect via STUN
     enableLogging: false, // Set true for debugging
@@ -145,12 +145,13 @@ Build the bundled executable and run it:
 ```bash
 swift build -c release
 .build/release/swift-ftr --help
-.build/release/swift-ftr example.com -m 30 -w 1.0
+.build/release/swift-ftr example.com -m 30 -w 2.0
 ```
 
 Selected options (ArgumentParser-powered):
 - `-m, --max-hops N`: Max TTL/hops to probe (default 30)
-- `-w, --timeout SEC`: Overall wait after sending probes (default 1.0)
+- `-w, --timeout SEC`: Overall wait after sending probes (default 2.0)
+- `-v, --version`: Print the swift-ftr version and exit
 - `-i, --interface IFACE`: Use specific network interface (e.g., en0)
 - `-s, --source IP`: Bind to specific source IP address
 - `-p, --payload-size N`: ICMP payload size in bytes (default 56)
@@ -161,7 +162,7 @@ Selected options (ArgumentParser-powered):
 
 Example: JSON output
 ```bash
-.build/release/swift-ftr --json www.example.com -m 30 -w 1.0
+.build/release/swift-ftr --json www.example.com -m 30 -w 2.0
 ```
 
 Configuration and Flags
@@ -169,7 +170,7 @@ Configuration and Flags
 - Prefer `SwiftFTRConfig(publicIP: ...)` to bypass STUN discovery when desired.
 - Use `SwiftFTRConfig(interface: "en0")` to bind to a specific network interface.
 - Use `SwiftFTRConfig(sourceIP: "192.168.1.100")` to bind to a specific source IP.
-- CLI: `--public-ip x.y.z.w`, `--verbose`, `--payload-size`, `--max-hops`, `--timeout`, `-i/--interface`, `-s/--source`.
+- CLI: `--public-ip x.y.z.w`, `--verbose`, `--payload-size`, `--max-hops`, `--timeout`, `-i/--interface`, `-s/--source`, `-v/--version`.
 
 Design Details
 --------------

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ swift build -c release
 
 Selected options (ArgumentParser-powered):
 - `-m, --max-hops N`: Max TTL/hops to probe (default 30)
-- `-w, --timeout SEC`: Overall wait after sending probes (default 2.0)
+- `-w, --timeout MS`: Probe timeout in milliseconds (default 2000)
 - `-v, --version`: Print the swift-ftr version and exit
 - `-i, --interface IFACE`: Use specific network interface (e.g., en0)
 - `-s, --source IP`: Bind to specific source IP address

--- a/Sources/SwiftFTR/RDNSCache.swift
+++ b/Sources/SwiftFTR/RDNSCache.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Actor-based cache for reverse DNS lookups with TTL and LRU eviction.
 ///
 /// This cache provides thread-safe storage for hostname lookups with automatic
-/// expiration and size-based eviction. It uses Swift 6.1's actor isolation for
+/// expiration and size-based eviction. It uses Swift 6.2's actor isolation for
 /// thread safety and the Clock API for accurate timing.
 actor RDNSCache {
   private struct CacheEntry {

--- a/Sources/SwiftFTR/Segmentation.swift
+++ b/Sources/SwiftFTR/Segmentation.swift
@@ -91,6 +91,7 @@ public struct TraceClassifier: Sendable {
   ///   - timeout: Per-lookup timeout in seconds.
   ///   - publicIP: Override public IP (bypasses STUN if provided).
   ///   - interface: Network interface to use for STUN discovery (if needed).
+  ///   - sourceIP: Source IPv4 address to bind ASN/STUN lookups to when explicit binding is required.
   ///   - enableLogging: Enable verbose logging for debugging.
   /// - Returns: A ClassifiedTrace with per-hop categories and ASNs when available.
   public func classify(

--- a/Sources/SwiftFTR/SwiftFTR.docc/SwiftFTR.md
+++ b/Sources/SwiftFTR/SwiftFTR.docc/SwiftFTR.md
@@ -18,7 +18,7 @@ Massively parallel, async/await traceroute for macOS using ICMP datagram sockets
 ```swift
 import SwiftFTR
 
-let tracer = SwiftFTR(config: SwiftFTRConfig(maxHops: 30, maxWaitMs: 1000))
+let tracer = SwiftFTR(config: SwiftFTRConfig(maxHops: 30, maxWaitMs: 2000))
 let result = try await tracer.trace(to: "1.1.1.1")
 for hop in result.hops {
     print(hop.ttl, hop.ipAddress ?? "*", hop.rtt ?? 0)

--- a/Sources/SwiftFTR/SwiftFTR.docc/SwiftFTR.md
+++ b/Sources/SwiftFTR/SwiftFTR.docc/SwiftFTR.md
@@ -39,7 +39,7 @@ for hop in classified.hops {
 
 ## Configuration
 
-- Use ``SwiftFTRConfig(publicIP:)`` to override/bypass STUN public IP discovery.
+- Use ``SwiftFTRConfig`` to override/bypass STUN discovery (`publicIP`) or bind to a specific interface/IP pair.
 - Inject a custom ``SwiftFTR/ASNResolver`` for offline or deterministic lookups.
 
 ## Topics

--- a/Sources/SwiftFTR/Traceroute.swift
+++ b/Sources/SwiftFTR/Traceroute.swift
@@ -109,7 +109,7 @@ public enum TracerouteError: Error, CustomStringConvertible {
 public struct SwiftFTRConfig: Sendable {
   /// Maximum TTL/hops to probe (default: 30)
   public let maxHops: Int
-  /// Maximum wait time per probe in milliseconds (default: 1000ms)
+  /// Maximum wait time per probe in milliseconds (default: 2000ms)
   public let maxWaitMs: Int
   /// Size in bytes of the Echo payload (default: 56)
   public let payloadSize: Int
@@ -131,7 +131,7 @@ public struct SwiftFTRConfig: Sendable {
 
   public init(
     maxHops: Int = 30,
-    maxWaitMs: Int = 1000,
+    maxWaitMs: Int = 2000,
     payloadSize: Int = 56,
     publicIP: String? = nil,
     enableLogging: Bool = false,

--- a/Sources/SwiftFTR/Version.swift
+++ b/Sources/SwiftFTR/Version.swift
@@ -1,0 +1,4 @@
+public enum SwiftFTRVersion {
+  /// Current semantic version for SwiftFTR.
+  public static let current = "0.4.0"
+}

--- a/Tests/SwiftFTRTests/ComprehensiveTests.swift
+++ b/Tests/SwiftFTRTests/ComprehensiveTests.swift
@@ -8,7 +8,7 @@ final class ComprehensiveIntegrationTests: XCTestCase {
   func testDefaultConfiguration() async throws {
     let config = SwiftFTRConfig()
     XCTAssertEqual(config.maxHops, 30)
-    XCTAssertEqual(config.maxWaitMs, 1000)
+    XCTAssertEqual(config.maxWaitMs, 2000)
     XCTAssertEqual(config.payloadSize, 56)
     XCTAssertNil(config.publicIP)
     XCTAssertFalse(config.enableLogging)

--- a/Tests/SwiftFTRTests/ConfigurationTests.swift
+++ b/Tests/SwiftFTRTests/ConfigurationTests.swift
@@ -47,7 +47,7 @@ final class ConfigurationTests: XCTestCase {
     // Test default config
     let defaultConfig = SwiftFTRConfig()
     XCTAssertEqual(defaultConfig.maxHops, 30)
-    XCTAssertEqual(defaultConfig.maxWaitMs, 1000)
+    XCTAssertEqual(defaultConfig.maxWaitMs, 2000)
     XCTAssertEqual(defaultConfig.payloadSize, 56)
     XCTAssertNil(defaultConfig.publicIP)
     XCTAssertFalse(defaultConfig.enableLogging)

--- a/Tests/SwiftFTRTests/StressTests.swift
+++ b/Tests/SwiftFTRTests/StressTests.swift
@@ -14,7 +14,8 @@ final class StressAndEdgeCaseTests: XCTestCase {
       let result = try await tracer.trace(to: "1.1.1.1")
       XCTAssertFalse(result.hops.isEmpty, "Trace \(i) should have hops")
       // Allow more tolerance for CI environments and network variance
-      XCTAssertLessThanOrEqual(result.duration, 1.5, "Trace \(i) should complete within reasonable time")
+      XCTAssertLessThanOrEqual(
+        result.duration, 1.5, "Trace \(i) should complete within reasonable time")
     }
   }
 

--- a/docs/development/CLAUDE.md
+++ b/docs/development/CLAUDE.md
@@ -92,7 +92,7 @@ swift build -c release -Xswiftc -sanitize=address -Xswiftc -sanitize=undefined
 
 ## Platform Requirements
 
-- Swift 6.1+ (Xcode 16.4+)
+- Swift 6.2+ (Xcode 26+)
 - macOS 13+
 - IPv4 only (uses ICMPv4 Echo)
 - Requires ICMP datagram socket support (macOS specific, no sudo needed)
@@ -118,3 +118,4 @@ swift build -c release -Xswiftc -sanitize=address -Xswiftc -sanitize=undefined
 - DNS/ASN lookups are injectable for testing
 - Formatting enforced via `swift format` in CI
 - Optional git hooks available: `git config core.hooksPath .githooks`
+- Concurrency defaults follow Swift 6.2 guidance: CLI targets pass `-default-isolation MainActor`, helper APIs use `@concurrent`, and upcoming features `NonisolatedNonsendingByDefault` + `InferIsolatedConformances` stay enabled.

--- a/docs/development/CLAUDE.md
+++ b/docs/development/CLAUDE.md
@@ -85,7 +85,7 @@ swift build -c release -Xswiftc -sanitize=address -Xswiftc -sanitize=undefined
 
 `SwiftFTRConfig` controls behavior:
 - `maxHops`: Maximum TTL to probe (default: 30)
-- `maxWaitMs`: Timeout in milliseconds (default: 1000)
+- `maxWaitMs`: Timeout in milliseconds (default: 2000)
 - `payloadSize`: ICMP payload size (default: 56)
 - `publicIP`: Override public IP to skip STUN
 - `enableLogging`: Debug logging flag

--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current Version: 0.4.0 (September 2025)
 - ✅ Core traceroute functionality with ICMP datagram sockets
-- ✅ Swift 6.1 concurrency compliance
+- ✅ Swift 6.2 concurrency compliance
 - ✅ Thread-safe, nonisolated API
 - ✅ ASN resolution via DNS (Team Cymru)
 - ✅ Hop categorization (LOCAL, ISP, TRANSIT, DESTINATION)
@@ -10,7 +10,7 @@
 - ✅ Comprehensive test suite
 - ✅ Enhanced error handling with contextual details
 - ✅ CLI improvements with verbose logging and payload size configuration
-- ✅ Actor-based architecture using Swift 6.1 features
+- ✅ Actor-based architecture using Swift 6.2 features
 - ✅ Reverse DNS (rDNS) support with caching (86400s default TTL)
 - ✅ STUN public IP caching between traces
 - ✅ Trace cancellation support for network changes
@@ -192,7 +192,7 @@ We welcome contributions! Priority areas:
 ## Dependencies & Integration Points
 
 ### Current Dependencies
-- Swift 6.1+ (minimum requirement)
+- Swift 6.2+ (minimum requirement)
 - macOS 13+ (ICMP datagram socket support)
 - Swift Concurrency with actors (v0.3.0+)
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -98,7 +98,7 @@ To run complete integration tests, set up a self-hosted runner:
 Requirements for self-hosted runners:
 - macOS 13+ (for ICMP datagram socket support)
 - Network access to internet
-- Swift 6.1+
+- Swift 6.2+
 - GitHub Actions runner software
 
 ## Network Topology Considerations

--- a/docs/guides/EXAMPLES.md
+++ b/docs/guides/EXAMPLES.md
@@ -46,7 +46,7 @@ import SwiftFTR
 // Configure all options
 let config = SwiftFTRConfig(
     maxHops: 20,           // Maximum TTL to probe (default: 30)
-    maxWaitMs: 2000,       // Max wait time in milliseconds (default: 1000)
+    maxWaitMs: 2000,       // Max wait time in milliseconds (default: 2000)
     payloadSize: 32,       // ICMP payload size in bytes (default: 56)
     publicIP: "1.2.3.4",   // Override public IP (skips STUN)
     enableLogging: true    // Enable debug logging (default: false)

--- a/docs/reference/AI_REFERENCE.md
+++ b/docs/reference/AI_REFERENCE.md
@@ -57,7 +57,7 @@ Configuration for traceroute behavior and caching.
 ```swift
 public struct SwiftFTRConfig: Sendable {
     public let maxHops: Int           // Maximum TTL to probe (default: 30)
-    public let maxWaitMs: Int          // Timeout in milliseconds (default: 1000)
+    public let maxWaitMs: Int          // Timeout in milliseconds (default: 2000)
     public let payloadSize: Int        // ICMP payload size in bytes (default: 56)
     public let publicIP: String?       // Override public IP (default: nil, auto-detect)
     public let enableLogging: Bool     // Enable debug logging (default: false)
@@ -69,7 +69,7 @@ public struct SwiftFTRConfig: Sendable {
 
     public init(
         maxHops: Int = 30,
-        maxWaitMs: Int = 1000,
+        maxWaitMs: Int = 2000,
         payloadSize: Int = 56,
         publicIP: String? = nil,
         enableLogging: Bool = false,

--- a/docs/reference/AI_REFERENCE.md
+++ b/docs/reference/AI_REFERENCE.md
@@ -5,9 +5,9 @@ SwiftFTR is a Swift library for performing fast, parallel traceroute operations 
 
 ## Core Requirements
 - **Platform**: macOS 13.0+
-- **Swift**: 6.1+
+- **Swift**: 6.2+
 - **Permissions**: No sudo required (uses SOCK_DGRAM)
-- **Concurrency**: Actor-based architecture with Swift 6 strict concurrency
+- **Concurrency**: Actor-based architecture with Swift 6.2 "Approachable Concurrency" defaults (`-default-isolation MainActor`, `@concurrent` helpers, upcoming features `NonisolatedNonsendingByDefault` & `InferIsolatedConformances`)
 
 ## Installation
 
@@ -825,7 +825,7 @@ public func stunGetPublicIPv4(
 ### Sendable Conformance
 - All public types conform to Sendable
 - Safe to pass between actor boundaries
-- No data races under Swift 6 strict concurrency
+- No data races under Swift 6.2 strict concurrency
 
 ## Network Protocols Used
 
@@ -1113,6 +1113,6 @@ SwiftFTR provides a comprehensive, production-ready traceroute implementation fo
 - rDNS support
 - Caching for performance
 - Thread-safe actor design
-- Swift 6 concurrency compliance
+- Swift 6.2 concurrency compliance
 
 Use it for network diagnostics, monitoring, path analysis, and understanding internet routing from Swift applications.

--- a/docs/reference/AI_REFERENCE.md
+++ b/docs/reference/AI_REFERENCE.md
@@ -1033,7 +1033,7 @@ swift build -c release
 # With options
 .build/release/swift-ftr example.com \
     --max-hops 20 \
-    --timeout 2.0 \
+    --timeout 2000 \
     --payload-size 64 \
     --json \
     --no-rdns \

--- a/docs/releases/RELEASE_NOTES_v0.3.0.md
+++ b/docs/releases/RELEASE_NOTES_v0.3.0.md
@@ -145,7 +145,7 @@ None. This release maintains full backward compatibility.
 - Removed deprecated `host` property from `TraceHop`
 
 ## 📦 Dependencies
-- Swift 6.1+ (required)
+- Swift 6.2+ (required)
 - macOS 13+ (required)
 - No external dependencies
 


### PR DESCRIPTION
## Summary
- raise the toolchain to Swift 6.2/Xcode 26 and enable the repo-wide "Approachable Concurrency" upcoming features
- document the new baseline, bump default probe timeout to 2000ms, and add CLI version flag plus millisecond timeout handling
- regenerate DocC, sync tests/docs, and ensure the CLI shows extended help when no host is provided

## Testing
- swift package --allow-writing-to-directory docc generate-documentation --target SwiftFTR --output-path docc --transform-for-static-hosting
- swift format --in-place -r Sources Tests
- PTR_SKIP_STUN=1 swift test -c debug