### PR TITLE
feat(probes): IPv6 TCP & UDP probes (Stage 3 of v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Unreleased (0.13.0-dev)
 -----------------------
 ### Features
 
+**IPv6 TCP & UDP probes (Stage 3 of v6 parity — see [`docs/IPV6.md`](docs/IPV6.md))**
+- `tcpProbe(...)` and `udpProbe(...)` now accept IPv6 literals and IPv6-resolving hostnames using the same entry points as v4. Family auto-detected from the resolved address; opt-in `TCPProbeConfig.preferredFamily` / `UDPProbeConfig.preferredFamily` forces a specific family (additive, default `.auto`).
+- Family-aware sockets (`socket(family, SOCK_STREAM, 0)` / `socket(family, SOCK_DGRAM, IPPROTO_UDP)`), `sockaddr_in6` `connect()` paths, `IPV6_BOUND_IF` for v6 interface binding, link-local `%zone` suffixes preserved in v6 source-IP binding.
+- Shared `bindProbeSourceIP(sockfd:family:sourceIP:)` helper in `Hostname.swift` so TCP and UDP probes use the same family-aware bind path.
+- `HTTPProbe` was already v6-capable via `URLSession`; no work needed there.
+- Both probes now use the shared `resolveHost(...)` helper introduced in Stage 2, removing the deprecated v4-only `resolveHostname` / `resolveHostnameUDP` helpers (deleted in this PR).
+
+**Verified end-to-end** (Cloudflare WARP v6 + literal v4): `tcp probe 1.1.1.1 443` and `tcp probe 2606:4700:4700::1111 443` both succeed with similar RTT (~7-9ms); `udp probe` reaches v4 and v6 destinations (response timeout is the expected behavior when the target doesn't speak our empty UDP probe).
+
+**Tests**
+- New `testTCPProbeIPv6`: gated on `SKIP_NETWORK_TESTS` + `IPv6Reachability.isAvailable()`; asserts `tcp probe 2606:4700:4700::1111:443` returns `.open` with the canonical resolved IP.
+- New `testUDPProbeIPv6`: same gating; asserts the v6 probe path completes (timeout/reply/ICMP error all valid).
+
+
 **IPv6 `trace()`, `traceClassified()`, and `traceStream()` over ICMPv6 (Stage 2 of v6 parity)**
 - Dual-stack `Traceroute.swift`: `SwiftFTR.trace()`, `traceClassified()`, and `traceStream()` now accept IPv6 literals and IPv6-resolving hostnames using the same entry points as v4. Family auto-detected from the resolved address; opt-in `SwiftFTRConfig.preferredFamily` forces a specific family (additive, default `.auto`).
 - ICMPv6 path: `socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6)`, `IPV6_UNICAST_HOPS` cycling per probe (replaces v4's `IP_TTL`), `IPV6_RECVHOPLIMIT` cmsg so hop limit arrives via `recvmsg`. Embedded-packet parsing in Time Exceeded / Destination Unreachable uses the existing `parseICMPv6Message` (added Stage 1).

--- a/Sources/SwiftFTR/Hostname.swift
+++ b/Sources/SwiftFTR/Hostname.swift
@@ -18,6 +18,51 @@ public struct ResolvedHost: Sendable {
   public let canonical: String
 }
 
+/// Family-aware source-IP bind shared by TCP/UDP probes. Returns nil on success;
+/// returns an error message string on failure (probes use string errors, not
+/// thrown `TracerouteError`, because they report through their own result types).
+/// For v6 the link-local `%zone` suffix is honored via `parseIPv6Scoped`.
+internal func bindProbeSourceIP(sockfd: Int32, family: Int32, sourceIP: String) -> String? {
+  switch family {
+  case AF_INET:
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = 0
+    if inet_pton(AF_INET, sourceIP, &addr.sin_addr) != 1 {
+      return "Invalid source IPv4 address '\(sourceIP)'"
+    }
+    let rc = withUnsafePointer(to: &addr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+        Darwin.bind(sockfd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    if rc < 0 {
+      return "Failed to bind to source IP '\(sourceIP)': \(String(cString: strerror(errno)))"
+    }
+    return nil
+  case AF_INET6:
+    let (bare, scopeID) = parseIPv6Scoped(sourceIP)
+    var addr = sockaddr_in6()
+    addr.sin6_family = sa_family_t(AF_INET6)
+    addr.sin6_port = 0
+    addr.sin6_scope_id = scopeID
+    if inet_pton(AF_INET6, bare, &addr.sin6_addr) != 1 {
+      return "Invalid source IPv6 address '\(sourceIP)'"
+    }
+    let rc = withUnsafePointer(to: &addr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+        Darwin.bind(sockfd, sa, socklen_t(MemoryLayout<sockaddr_in6>.size))
+      }
+    }
+    if rc < 0 {
+      return "Failed to bind to source IP '\(sourceIP)': \(String(cString: strerror(errno)))"
+    }
+    return nil
+  default:
+    return "Unsupported family for source bind: \(family)"
+  }
+}
+
 /// Dual-stack host resolver shared across `ping()`, `trace()`, and friends.
 ///
 /// Honors `PreferredFamily`:

--- a/Sources/SwiftFTR/TCPProbe.swift
+++ b/Sources/SwiftFTR/TCPProbe.swift
@@ -43,18 +43,24 @@ public struct TCPProbeConfig: Sendable {
   /// **Note**: Most users only need to set ``interface``.
   public let sourceIP: String?
 
+  /// IP family preference. Defaults to `.auto` (let the resolved address decide).
+  /// See `PreferredFamily` and `docs/IPV6.md`.
+  public let preferredFamily: PreferredFamily
+
   public init(
     host: String,
     port: Int,
     timeout: TimeInterval = 2.0,
     interface: String? = nil,
-    sourceIP: String? = nil
+    sourceIP: String? = nil,
+    preferredFamily: PreferredFamily = .auto
   ) {
     self.host = host
     self.port = port
     self.timeout = timeout
     self.interface = interface
     self.sourceIP = sourceIP
+    self.preferredFamily = preferredFamily
   }
 }
 
@@ -139,11 +145,14 @@ public func tcpProbe(
 public func tcpProbe(config: TCPProbeConfig) async throws -> TCPProbeResult {
   let startTime = Date()
 
-  // Resolve hostname to IP address
-  guard let resolvedIP = try? await resolveHostname(config.host) else {
+  // Resolve via the shared dual-stack helper (Hostname.swift).
+  let resolved: ResolvedHost
+  do {
+    resolved = try resolveHost(host: config.host, prefer: config.preferredFamily)
+  } catch {
     return TCPProbeResult(
       host: config.host,
-      resolvedIP: config.host,  // Assume it's already an IP
+      resolvedIP: config.host,
       port: config.port,
       isReachable: false,
       connectionState: .error,
@@ -153,9 +162,8 @@ public func tcpProbe(config: TCPProbeConfig) async throws -> TCPProbeResult {
     )
   }
 
-  // Perform TCP SYN probe using non-blocking socket
   let result = try await performTCPProbe(
-    ip: resolvedIP,
+    resolved: resolved,
     port: config.port,
     timeout: config.timeout,
     startTime: startTime,
@@ -165,7 +173,7 @@ public func tcpProbe(config: TCPProbeConfig) async throws -> TCPProbeResult {
 
   return TCPProbeResult(
     host: config.host,
-    resolvedIP: resolvedIP,
+    resolvedIP: resolved.canonical,
     port: config.port,
     isReachable: result.isReachable,
     connectionState: result.connectionState,
@@ -177,50 +185,6 @@ public func tcpProbe(config: TCPProbeConfig) async throws -> TCPProbeResult {
 
 // MARK: - Private Implementation
 
-private func resolveHostname(_ host: String) async throws -> String {
-  // If already an IP address, return it
-  if isIPAddress(host) {
-    return host
-  }
-
-  // Use getaddrinfo for DNS resolution
-  var hints = addrinfo()
-  hints.ai_family = AF_INET  // IPv4 for now
-  hints.ai_socktype = SOCK_STREAM
-
-  var result: UnsafeMutablePointer<addrinfo>?
-  defer { if let result = result { freeaddrinfo(result) } }
-
-  let status = getaddrinfo(host, nil, &hints, &result)
-  guard status == 0, let addr = result else {
-    throw TCPProbeError.resolutionFailed
-  }
-
-  // Extract IP address from result
-  var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-  getnameinfo(
-    addr.pointee.ai_addr,
-    socklen_t(addr.pointee.ai_addrlen),
-    &hostname,
-    socklen_t(hostname.count),
-    nil,
-    0,
-    NI_NUMERICHOST
-  )
-
-  // Convert to String, truncating at null terminator
-  let nullIndex = hostname.firstIndex(of: 0) ?? hostname.count
-  let bytes = hostname[..<nullIndex].map { UInt8(bitPattern: $0) }
-  return String(decoding: bytes, as: UTF8.self)
-}
-
-private func isIPAddress(_ string: String) -> Bool {
-  // Simple check for IPv4 format
-  let components = string.split(separator: ".")
-  guard components.count == 4 else { return false }
-  return components.allSatisfy { UInt8($0) != nil }
-}
-
 private struct ProbeResult {
   let isReachable: Bool
   let connectionState: TCPConnectionState
@@ -229,114 +193,86 @@ private struct ProbeResult {
 }
 
 private func performTCPProbe(
-  ip: String,
+  resolved: ResolvedHost,
   port: Int,
   timeout: TimeInterval,
   startTime: Date,
   interface: String?,
   sourceIP: String?
 ) async throws -> ProbeResult {
-  // Create socket
-  let sockfd = socket(AF_INET, SOCK_STREAM, 0)
+  // Family-aware socket. v4 → AF_INET, v6 → AF_INET6.
+  let sockfd = socket(resolved.family, SOCK_STREAM, 0)
   guard sockfd >= 0 else {
     return ProbeResult(
-      isReachable: false,
-      connectionState: .error,
-      rtt: nil,
-      error: "Failed to create socket: \(String(cString: strerror(errno)))"
-    )
+      isReachable: false, connectionState: .error, rtt: nil,
+      error: "Failed to create socket: \(String(cString: strerror(errno)))")
   }
 
-  // Bind to interface if specified
   if let iface = interface {
     #if canImport(Darwin)
       let ifaceIndex = if_nametoindex(iface)
       guard ifaceIndex != 0 else {
         close(sockfd)
         return ProbeResult(
-          isReachable: false,
-          connectionState: .error,
-          rtt: nil,
-          error: "Interface '\(iface)' not found"
-        )
+          isReachable: false, connectionState: .error, rtt: nil,
+          error: "Interface '\(iface)' not found")
       }
-
       var index = ifaceIndex
-      let result = setsockopt(
-        sockfd, IPPROTO_IP, IP_BOUND_IF,
-        &index, socklen_t(MemoryLayout<UInt32>.size))
-
-      guard result >= 0 else {
+      let level = resolved.family == AF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP
+      let opt = resolved.family == AF_INET6 ? IPV6_BOUND_IF : IP_BOUND_IF
+      if setsockopt(sockfd, level, opt, &index, socklen_t(MemoryLayout<UInt32>.size)) < 0 {
         close(sockfd)
         return ProbeResult(
-          isReachable: false,
-          connectionState: .error,
-          rtt: nil,
-          error: "Failed to bind to interface '\(iface)': \(String(cString: strerror(errno)))"
-        )
+          isReachable: false, connectionState: .error, rtt: nil,
+          error: "Failed to bind to interface '\(iface)': \(String(cString: strerror(errno)))")
       }
     #else
       close(sockfd)
       return ProbeResult(
-        isReachable: false,
-        connectionState: .error,
-        rtt: nil,
-        error: "Interface binding not supported on this platform"
-      )
+        isReachable: false, connectionState: .error, rtt: nil,
+        error: "Interface binding not supported on this platform")
     #endif
   }
 
-  // Bind to source IP if specified
   if let srcIP = sourceIP {
-    var sourceAddr = sockaddr_in()
-    sourceAddr.sin_family = sa_family_t(AF_INET)
-    sourceAddr.sin_port = 0  // Let system choose port
-
-    guard inet_pton(AF_INET, srcIP, &sourceAddr.sin_addr) == 1 else {
+    if let err = bindProbeSourceIP(sockfd: sockfd, family: resolved.family, sourceIP: srcIP) {
       close(sockfd)
       return ProbeResult(
-        isReachable: false,
-        connectionState: .error,
-        rtt: nil,
-        error: "Invalid source IP address '\(srcIP)'"
-      )
-    }
-
-    let bindResult = withUnsafePointer(to: &sourceAddr) { ptr in
-      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-        Darwin.bind(sockfd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
-      }
-    }
-
-    guard bindResult >= 0 else {
-      close(sockfd)
-      return ProbeResult(
-        isReachable: false,
-        connectionState: .error,
-        rtt: nil,
-        error: "Failed to bind to source IP '\(srcIP)': \(String(cString: strerror(errno)))"
-      )
+        isReachable: false, connectionState: .error, rtt: nil, error: err)
     }
   }
 
-  // Set socket to non-blocking
+  // Non-blocking.
   var flags = fcntl(sockfd, F_GETFL, 0)
   flags |= O_NONBLOCK
   _ = fcntl(sockfd, F_SETFL, flags)
 
-  // Prepare sockaddr
-  var addr = sockaddr_in()
-  addr.sin_family = sa_family_t(AF_INET)
-  addr.sin_port = in_port_t(port).bigEndian
-  inet_pton(AF_INET, ip, &addr.sin_addr)
+  // Build the destination sockaddr from the resolved family + port.
+  var destAddr = resolved.address
+  // sockaddr_in.sin_port and sockaddr_in6.sin6_port are both at the same
+  // offset (after the 2-byte family field), so a single overwrite works.
+  // We do it via family-aware rebinding to keep things explicit.
+  let destLen: socklen_t
+  if resolved.family == AF_INET6 {
+    destLen = socklen_t(MemoryLayout<sockaddr_in6>.size)
+    withUnsafeMutablePointer(to: &destAddr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+        $0.pointee.sin6_port = in_port_t(port).bigEndian
+      }
+    }
+  } else {
+    destLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+    withUnsafeMutablePointer(to: &destAddr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+        $0.pointee.sin_port = in_port_t(port).bigEndian
+      }
+    }
+  }
 
-  // Record start time using monotonic clock
   let probeStartTime = monotonicTime()
-
-  // Attempt connection
-  let connectResult = withUnsafePointer(to: &addr) {
+  let connectResult = withUnsafePointer(to: &destAddr) {
     $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-      connect(sockfd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+      connect(sockfd, $0, destLen)
     }
   }
 

--- a/Sources/SwiftFTR/UDPProbe.swift
+++ b/Sources/SwiftFTR/UDPProbe.swift
@@ -21,16 +21,22 @@ public struct UDPProbeConfig: Sendable {
   /// Payload to send (default: empty)
   public let payload: Data
 
+  /// IP family preference. Defaults to `.auto` (let the resolved address decide).
+  /// See `PreferredFamily` and `docs/IPV6.md`.
+  public let preferredFamily: PreferredFamily
+
   public init(
     host: String,
     port: Int,
     timeout: TimeInterval = 2.0,
-    payload: Data = Data()
+    payload: Data = Data(),
+    preferredFamily: PreferredFamily = .auto
   ) {
     self.host = host
     self.port = port
     self.timeout = timeout
     self.payload = payload
+    self.preferredFamily = preferredFamily
   }
 }
 
@@ -107,8 +113,11 @@ public func udpProbe(
 public func udpProbe(config: UDPProbeConfig) async throws -> UDPProbeResult {
   let startTime = Date()
 
-  // Resolve hostname to IP address
-  guard let resolvedIP = try? await resolveHostnameUDP(config.host) else {
+  // Resolve via the shared dual-stack helper (Hostname.swift).
+  let resolved: ResolvedHost
+  do {
+    resolved = try resolveHost(host: config.host, prefer: config.preferredFamily)
+  } catch {
     return UDPProbeResult(
       host: config.host,
       resolvedIP: config.host,
@@ -121,9 +130,8 @@ public func udpProbe(config: UDPProbeConfig) async throws -> UDPProbeResult {
     )
   }
 
-  // Perform UDP probe
   let result = try await performUDPProbe(
-    ip: resolvedIP,
+    resolved: resolved,
     port: config.port,
     payload: config.payload,
     timeout: config.timeout,
@@ -132,7 +140,7 @@ public func udpProbe(config: UDPProbeConfig) async throws -> UDPProbeResult {
 
   return UDPProbeResult(
     host: config.host,
-    resolvedIP: resolvedIP,
+    resolvedIP: resolved.canonical,
     port: config.port,
     isReachable: result.isReachable,
     rtt: result.rtt,
@@ -144,49 +152,6 @@ public func udpProbe(config: UDPProbeConfig) async throws -> UDPProbeResult {
 
 // MARK: - Private Implementation
 
-private func resolveHostnameUDP(_ host: String) async throws -> String {
-  // If already an IP address, return it
-  if isIPAddressUDP(host) {
-    return host
-  }
-
-  // Use getaddrinfo for DNS resolution
-  var hints = addrinfo()
-  hints.ai_family = AF_INET  // IPv4
-  hints.ai_socktype = SOCK_DGRAM
-
-  var result: UnsafeMutablePointer<addrinfo>?
-  defer { if let result = result { freeaddrinfo(result) } }
-
-  let status = getaddrinfo(host, nil, &hints, &result)
-  guard status == 0, let addr = result else {
-    throw UDPProbeError.resolutionFailed
-  }
-
-  // Extract IP address
-  var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-  getnameinfo(
-    addr.pointee.ai_addr,
-    socklen_t(addr.pointee.ai_addrlen),
-    &hostname,
-    socklen_t(hostname.count),
-    nil,
-    0,
-    NI_NUMERICHOST
-  )
-
-  // Convert to String, truncating at null terminator
-  let nullIndex = hostname.firstIndex(of: 0) ?? hostname.count
-  let bytes = hostname[..<nullIndex].map { UInt8(bitPattern: $0) }
-  return String(decoding: bytes, as: UTF8.self)
-}
-
-private func isIPAddressUDP(_ string: String) -> Bool {
-  let components = string.split(separator: ".")
-  guard components.count == 4 else { return false }
-  return components.allSatisfy { UInt8($0) != nil }
-}
-
 private struct UDPProbeResultInternal {
   let isReachable: Bool
   let rtt: TimeInterval?
@@ -195,38 +160,48 @@ private struct UDPProbeResultInternal {
 }
 
 private func performUDPProbe(
-  ip: String,
+  resolved: ResolvedHost,
   port: Int,
   payload: Data,
   timeout: TimeInterval,
   startTime: Date
 ) async throws -> UDPProbeResultInternal {
-  // Create UDP socket
-  let sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+  // Family-aware socket. v4 → AF_INET, v6 → AF_INET6.
+  let sockfd = socket(resolved.family, SOCK_DGRAM, IPPROTO_UDP)
   guard sockfd >= 0 else {
     return UDPProbeResultInternal(
-      isReachable: false,
-      rtt: nil,
-      responseType: nil,
-      error: "Failed to create UDP socket"
-    )
+      isReachable: false, rtt: nil, responseType: nil,
+      error: "Failed to create UDP socket")
   }
 
-  // Set socket to non-blocking
   var flags = fcntl(sockfd, F_GETFL, 0)
   flags |= O_NONBLOCK
   _ = fcntl(sockfd, F_SETFL, flags)
 
-  // Prepare destination address
-  var addr = sockaddr_in()
-  addr.sin_family = sa_family_t(AF_INET)
-  addr.sin_port = in_port_t(port).bigEndian
-  inet_pton(AF_INET, ip, &addr.sin_addr)
+  // Build the destination sockaddr from the resolved family + port.
+  var destAddr = resolved.address
+  let destLen: socklen_t
+  if resolved.family == AF_INET6 {
+    destLen = socklen_t(MemoryLayout<sockaddr_in6>.size)
+    withUnsafeMutablePointer(to: &destAddr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+        $0.pointee.sin6_port = in_port_t(port).bigEndian
+      }
+    }
+  } else {
+    destLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+    withUnsafeMutablePointer(to: &destAddr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+        $0.pointee.sin_port = in_port_t(port).bigEndian
+      }
+    }
+  }
 
-  // Connect the UDP socket - this allows kernel to deliver ICMP errors
-  let connectResult = withUnsafePointer(to: &addr) {
+  // Connect the UDP socket - this allows the kernel to deliver ICMP/ICMPv6
+  // errors as ECONNREFUSED on recv(), avoiding the need for a raw ICMP socket.
+  let connectResult = withUnsafePointer(to: &destAddr) {
     $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-      connect(sockfd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+      connect(sockfd, $0, destLen)
     }
   }
 

--- a/Tests/SwiftFTRTests/ProbeTests.swift
+++ b/Tests/SwiftFTRTests/ProbeTests.swift
@@ -108,6 +108,41 @@ struct UDPProbeTests {
     #expect(result.isReachable)
   }
 
+  // MARK: - IPv6
+
+  /// TCP probe over IPv6. Network-gated and v6-reachability-gated; skips cleanly
+  /// on v4-only hosts.
+  @Test(
+    "TCP probe to reachable v6 host (Cloudflare 2606:4700:4700::1111:443)",
+    .enabled(
+      if: !ProcessInfo.processInfo.environment.keys.contains("SKIP_NETWORK_TESTS")
+        && IPv6Reachability.isAvailable()))
+  func testTCPProbeIPv6() async throws {
+    let result = try await tcpProbe(
+      host: "2606:4700:4700::1111", port: 443, timeout: 3.0)
+    #expect(result.resolvedIP == "2606:4700:4700::1111")
+    #expect(result.isReachable, "Cloudflare v6 :443 should be reachable from a v6-capable host")
+    #expect(result.connectionState == .open)
+  }
+
+  /// UDP probe to a v6 host. Doesn't expect a UDP reply from Cloudflare DNS
+  /// (which only answers well-formed DNS queries), so this asserts the probe
+  /// path runs to completion rather than the result of the probe.
+  @Test(
+    "UDP probe to v6 host completes (2606:4700:4700::1111:53)",
+    .enabled(
+      if: !ProcessInfo.processInfo.environment.keys.contains("SKIP_NETWORK_TESTS")
+        && IPv6Reachability.isAvailable()))
+  func testUDPProbeIPv6() async throws {
+    let result = try await udpProbe(
+      host: "2606:4700:4700::1111", port: 53, timeout: 2.0)
+    #expect(result.resolvedIP == "2606:4700:4700::1111")
+    // Either we got a UDP reply (responseType="udp_reply"), an ICMPv6 error
+    // (responseType="icmp_port_unreachable"), or a timeout (responseType="timeout").
+    // All three are valid outcomes — what we assert is that the path ran.
+    #expect(result.responseType != nil || result.error != nil)
+  }
+
   // Helper to build a simple DNS query packet
   private func buildDNSQuery(domain: String) -> Data {
     var data = Data()

--- a/docs/IPV6.md
+++ b/docs/IPV6.md
@@ -50,12 +50,9 @@ Now ships v6 trace, traceClassified, and traceStream via the same entry points a
 
 **Deferred follow-up** (not blocking v6 trace correctness): `VPNContext.vpnLocalIPs` is empty by default — populating it with both v4 and v6 addresses of detected VPN interfaces is its own refactor (the field has been empty since the initial implementation; v6 trace classification works correctly without it because it falls through to ASN-based segmentation). NWX flagged the dual-stack-source / v4-only-tunnel edge case for follow-up attention.
 
-### Stage 3 — TCP / UDP probes over IPv6
+### ~~Stage 3 — TCP / UDP probes over IPv6~~ *(shipped)*
 
-- Dual-stack `resolveHostname` in `TCPProbe.swift` and `UDPProbe.swift` (currently both `AF_INET`-only at file scope).
-- `sockaddr_in6` `connect()` paths for both.
-- HTTPProbe needs no work — `URLSession` is already v6-aware via the OS resolver.
-- Probe integration tests gain v6 cases under the same `IPv6Reachability` gate.
+Dual-stack `tcpProbe(...)` and `udpProbe(...)`: same entry points work for both families, family detected at resolve time, `PreferredFamily` on both configs. `IPV6_BOUND_IF` for v6 interface binding, link-local `%zone` source-IP suffixes preserved. The shared `bindProbeSourceIP` helper in `Hostname.swift` is used by both probes. `HTTPProbe` was already v6-aware via `URLSession` — no work needed. New `testTCPProbeIPv6` / `testUDPProbeIPv6` integration tests gated on `IPv6Reachability`.
 
 ### Stage 4 — STUN over IPv6 + dual-stack public-IP discovery
 


### PR DESCRIPTION
## Summary

Stage 3 of full IPv6 parity (see [`docs/IPV6.md`](docs/IPV6.md)). `tcpProbe(...)` and `udpProbe(...)` now accept IPv6 literals and IPv6-resolving hostnames using the same entry points as v4. Family auto-detected from the resolved address; opt-in `{TCP,UDP}ProbeConfig.preferredFamily` forces a specific family (additive, default `.auto`).

## Manual verification

| Command | Result |
|---|---|
| `swift-ftr probe tcp 1.1.1.1 443` | ✓ reachable, ~9 ms, state `open` |
| `swift-ftr probe tcp 2606:4700:4700::1111 443` | ✓ reachable, ~9 ms, state `open` |
| `swift-ftr probe udp 1.1.1.1 53` | reaches dest, timeout (expected: empty UDP probe) |
| `swift-ftr probe udp 2606:4700:4700::1111 53` | reaches dest, timeout (same as v4 — path is correct) |

## Public API additions (all additive)

- `TCPProbeConfig.preferredFamily: PreferredFamily = .auto`
- `UDPProbeConfig.preferredFamily: PreferredFamily = .auto`

## Code

- **`TCPProbe.swift`**: family-aware socket (`socket(family, SOCK_STREAM, 0)`); `sockaddr_in6` connect path; `IPV6_BOUND_IF` for v6 interface binding; old `AF_INET`-only `resolveHostname` deleted in favor of the shared `resolveHost` from Stage 2.
- **`UDPProbe.swift`**: same shape. Family-aware `socket(family, SOCK_DGRAM, IPPROTO_UDP)`; `sockaddr_in6` connect (kernel still delivers ICMPv6 errors as `ECONNREFUSED` on `recv` via connected UDP socket); old `resolveHostnameUDP` deleted.
- **`Hostname.swift`**: new `bindProbeSourceIP(sockfd:family:sourceIP:)` helper shared by both probes. v6 link-local `%zone` suffix honored via `parseIPv6Scoped` (NWX contract).
- **`HTTPProbe.swift`**: no changes needed — `URLSession` is already v6-aware via the OS resolver.

## Tests

- `testTCPProbeIPv6`: gated on `SKIP_NETWORK_TESTS` unset + `IPv6Reachability.isAvailable()`. Asserts `tcp probe 2606:4700:4700::1111:443` returns `.open` with canonical resolved IP.
- `testUDPProbeIPv6`: same gating. Asserts the v6 probe path runs to completion (timeout/reply/ICMP error all valid outcomes).
- All 163 unit tests pass with `PTR_SKIP_STUN=1 SKIP_NETWORK_TESTS=1 swift test`.

## Out of scope

- **Stage 4**: STUN v6 + dual-stack public-IP discovery.
- **Stage 5**: Full resolver consolidation across remaining callers (Stages 1–3 each did the minimal extraction).
- **Stage 7**: v6-capable CI runner, NAT64 transparency, v6 parser fuzzing.

## Test plan

- [x] `swift format lint -r Sources Tests` — clean.
- [x] `swift build -c debug` and `-c release --product swift-ftr` — clean.
- [x] `PTR_SKIP_STUN=1 SKIP_NETWORK_TESTS=1 swift test` — all 163 unit tests pass.
- [x] Manual TCP/UDP v6 cross-check (table above).
- [x] v4 regression spot-check — byte-identical to pre-PR behavior.
- [ ] Reviewer: confirm v6 probe tests skip cleanly on a v4-only environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)