### PR TITLE
refactor(hostname): consolidate resolver + bind helpers (Stage 5 of v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented here. This project follows Se
 
 Unreleased (0.13.0-dev)
 -----------------------
+### Refactor
+
+**Resolver and bind-helper consolidation (Stage 5 of v6 parity — see [`docs/IPV6.md`](docs/IPV6.md))**
+
+Pure refactor; no behavior change, no public API change. Tidies up duplication that accumulated across Stages 1–4 now that every caller path is family-aware.
+
+- `Multipath.swift` was the last remaining caller of the old `resolveIPv4(host:enableLogging:) -> sockaddr_in` helper. Migrated to `resolveHost(host:, prefer: .v4)` (Multipath stays v4-only by design since ECMP probing is heavily tied to IPv4 paris-traceroute / 5-tuple semantics, but uses the shared resolver).
+- Deleted the now-unused `resolveIPv4` from `Traceroute.swift` (lines 1024–1064). `Hostname.resolveHost(host:prefer:)` is the only resolver in the codebase.
+- Renamed `bindProbeSourceIP` → `bindSourceIP` in `Hostname.swift` — no longer probe-specific; it's the shared family-aware source-IP bind for every socket path (ping, trace, probes, STUN).
+- Added new `bindInterface(sockfd:family:ifIndex:) -> String?` helper in `Hostname.swift` — same low-level shape as `bindSourceIP`. Centralizes the `IP_BOUND_IF` (v4) / `IPV6_BOUND_IF` (v6) `setsockopt` call.
+- `Traceroute.swift`'s `bindTraceInterface` and `bindTraceSourceIP` are now thin wrappers that delegate to the shared helpers and translate the string error to the typed `TracerouteError.{interfaceBindFailed, sourceIPBindFailed}` thrown by trace's caller contract.
+- `TCPProbe.swift` and `STUN.swift` now call `bindInterface` directly (was: inline `setsockopt` with hand-rolled level/opt branching). Tests untouched.
+
+The shared helpers (`resolveHost`, `bindSourceIP`, `bindInterface`) all live in `Hostname.swift` and are family-aware, so any future v6 work calls the same code paths v4 does.
+
 ### Features
 
 **IPv6 STUN + dual-stack public-IP discovery (Stage 4 of v6 parity — see [`docs/IPV6.md`](docs/IPV6.md))**

--- a/Sources/SwiftFTR/Hostname.swift
+++ b/Sources/SwiftFTR/Hostname.swift
@@ -18,11 +18,14 @@ public struct ResolvedHost: Sendable {
   public let canonical: String
 }
 
-/// Family-aware source-IP bind shared by TCP/UDP probes. Returns nil on success;
-/// returns an error message string on failure (probes use string errors, not
-/// thrown `TracerouteError`, because they report through their own result types).
+/// Family-aware source-IP bind shared across ping, trace, probes, and STUN.
+/// Returns nil on success; returns an error message string on failure. Callers
+/// that report errors via thrown types (e.g. `Traceroute`) wrap this and
+/// translate the string; callers that report via result types (probes) use the
+/// string directly.
+///
 /// For v6 the link-local `%zone` suffix is honored via `parseIPv6Scoped`.
-internal func bindProbeSourceIP(sockfd: Int32, family: Int32, sourceIP: String) -> String? {
+internal func bindSourceIP(sockfd: Int32, family: Int32, sourceIP: String) -> String? {
   switch family {
   case AF_INET:
     var addr = sockaddr_in()
@@ -61,6 +64,23 @@ internal func bindProbeSourceIP(sockfd: Int32, family: Int32, sourceIP: String) 
   default:
     return "Unsupported family for source bind: \(family)"
   }
+}
+
+/// Family-aware interface bind via `IP_BOUND_IF` (v4) or `IPV6_BOUND_IF` (v6).
+/// Returns nil on success; an error message string on failure. Caller is
+/// responsible for resolving `interfaceName` to `ifIndex` (typically via
+/// `if_nametoindex`) and for handling the `ifIndex == 0` failure case before
+/// invoking this — that lets callers produce more specific error messages
+/// (e.g. "interface not found" vs. "setsockopt failed").
+internal func bindInterface(sockfd: Int32, family: Int32, ifIndex: UInt32) -> String? {
+  var index = ifIndex
+  let level = family == AF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP
+  let opt = family == AF_INET6 ? IPV6_BOUND_IF : IP_BOUND_IF
+  if setsockopt(sockfd, level, opt, &index, socklen_t(MemoryLayout<UInt32>.size)) != 0 {
+    return
+      "setsockopt(\(family == AF_INET6 ? "IPV6_BOUND_IF" : "IP_BOUND_IF")) failed: \(String(cString: strerror(errno)))"
+  }
+  return nil
 }
 
 /// Dual-stack host resolver shared across `ping()`, `trace()`, and friends.

--- a/Sources/SwiftFTR/Multipath.swift
+++ b/Sources/SwiftFTR/Multipath.swift
@@ -640,9 +640,10 @@ extension SwiftFTR {
       Task { await handle.cancel() }
     }
 
-    // Resolve destination IP
-    let destAddr = try resolveIPv4(host: host, enableLogging: config.enableLogging)
-    let destIP = ipString(destAddr)
+    // Resolve destination IP via the shared dual-stack resolver. Multipath stays
+    // v4-only by design (ECMP probing is heavily tied to IPv4 paris-traceroute /
+    // 5-tuple semantics), so we force `.v4` rather than auto-detecting.
+    let destIP = try resolveHost(host: host, prefer: .v4).canonical
 
     // Collect IPs for batch operations
     var allIPs = Set(tr.hops.compactMap { $0.ipAddress })

--- a/Sources/SwiftFTR/STUN.swift
+++ b/Sources/SwiftFTR/STUN.swift
@@ -144,16 +144,11 @@ internal func stunGetPublicIP(
         throw STUNError.interfaceBindFailed(
           interface: interfaceName, errno: error, details: details)
       }
-      var index = ifIndex
-      // IP_BOUND_IF for v4, IPV6_BOUND_IF for v6.
-      let level = family == AF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP
-      let opt = family == AF_INET6 ? IPV6_BOUND_IF : IP_BOUND_IF
-      if setsockopt(fd, level, opt, &index, socklen_t(MemoryLayout<UInt32>.size)) != 0 {
+      if let errMsg = bindInterface(sockfd: fd, family: family, ifIndex: ifIndex) {
         let error = errno
-        let details = "Failed to bind STUN socket to interface index \(ifIndex)."
-        if enableLogging { print("[STUN] ERROR: \(details)") }
+        if enableLogging { print("[STUN] ERROR: \(errMsg)") }
         throw STUNError.interfaceBindFailed(
-          interface: interfaceName, errno: error, details: details)
+          interface: interfaceName, errno: error, details: errMsg)
       }
       if enableLogging {
         print("[STUN] Bound to interface '\(interfaceName)' (index: \(ifIndex))")
@@ -169,8 +164,7 @@ internal func stunGetPublicIP(
     if enableLogging {
       print("[STUN] Binding socket to source IP '\(srcIP)'...")
     }
-    // Reuse the family-aware probe source bind helper (added Stage 3).
-    if let errMsg = bindProbeSourceIP(sockfd: fd, family: family, sourceIP: srcIP) {
+    if let errMsg = bindSourceIP(sockfd: fd, family: family, sourceIP: srcIP) {
       if enableLogging { print("[STUN] ERROR: \(errMsg)") }
       throw STUNError.sourceIPBindFailed(sourceIP: srcIP, errno: errno, details: errMsg)
     }

--- a/Sources/SwiftFTR/TCPProbe.swift
+++ b/Sources/SwiftFTR/TCPProbe.swift
@@ -217,14 +217,11 @@ private func performTCPProbe(
           isReachable: false, connectionState: .error, rtt: nil,
           error: "Interface '\(iface)' not found")
       }
-      var index = ifaceIndex
-      let level = resolved.family == AF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP
-      let opt = resolved.family == AF_INET6 ? IPV6_BOUND_IF : IP_BOUND_IF
-      if setsockopt(sockfd, level, opt, &index, socklen_t(MemoryLayout<UInt32>.size)) < 0 {
+      if let errMsg = bindInterface(sockfd: sockfd, family: resolved.family, ifIndex: ifaceIndex) {
         close(sockfd)
         return ProbeResult(
           isReachable: false, connectionState: .error, rtt: nil,
-          error: "Failed to bind to interface '\(iface)': \(String(cString: strerror(errno)))")
+          error: "Failed to bind to interface '\(iface)': \(errMsg)")
       }
     #else
       close(sockfd)
@@ -235,7 +232,7 @@ private func performTCPProbe(
   }
 
   if let srcIP = sourceIP {
-    if let err = bindProbeSourceIP(sockfd: sockfd, family: resolved.family, sourceIP: srcIP) {
+    if let err = bindSourceIP(sockfd: sockfd, family: resolved.family, sourceIP: srcIP) {
       close(sockfd)
       return ProbeResult(
         isReachable: false, connectionState: .error, rtt: nil, error: err)

--- a/Sources/SwiftFTR/Traceroute.swift
+++ b/Sources/SwiftFTR/Traceroute.swift
@@ -1020,49 +1020,6 @@ public actor SwiftFTR {
   }
 }
 
-// Helpers
-internal func resolveIPv4(host: String, enableLogging: Bool = false) throws -> sockaddr_in {
-  if enableLogging {
-    print("[SwiftFTR] Resolving host: \(host)")
-  }
-  // Try numeric IPv4 first (fast path, works without DNS)
-  var addr = sockaddr_in()
-  addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-  addr.sin_family = sa_family_t(AF_INET)
-  if host.withCString({ inet_pton(AF_INET, $0, &addr.sin_addr) }) == 1 {
-    return addr
-  }
-
-  // Fall back to getaddrinfo for names
-  var hints = addrinfo(
-    ai_flags: AI_ADDRCONFIG,
-    ai_family: AF_INET,
-    ai_socktype: 0,
-    ai_protocol: 0,
-    ai_addrlen: 0,
-    ai_canonname: nil,
-    ai_addr: nil,
-    ai_next: nil
-  )
-  var res: UnsafeMutablePointer<addrinfo>? = nil
-  let err = getaddrinfo(host, nil, &hints, &res)
-  guard err == 0, let info = res else {
-    let details =
-      err != 0
-      ? "getaddrinfo error: \(String(cString: gai_strerror(err)))" : "Failed to get address info"
-    throw TracerouteError.resolutionFailed(host: host, details: details)
-  }
-  defer { freeaddrinfo(info) }
-  if info.pointee.ai_family == AF_INET, let sa = info.pointee.ai_addr {
-    memcpy(&addr, sa, min(MemoryLayout<sockaddr_in>.size, Int(info.pointee.ai_addrlen)))
-    addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-    addr.sin_family = sa.pointee.sa_family
-    return addr
-  }
-  throw TracerouteError.resolutionFailed(
-    host: host, details: "Host resolved but no IPv4 address available")
-}
-
 // MARK: - Dual-stack trace helpers (Stage 2 IPv6)
 
 // Stage 1 added these for the ping path in Ping.swift; the v6 socket constants
@@ -1117,18 +1074,17 @@ internal func setTraceHopLimit(sockfd: Int32, family: Int32, ttl: Int) throws {
 }
 
 /// Family-aware interface binding: v4 → `IP_BOUND_IF`, v6 → `IPV6_BOUND_IF`.
+/// Trace-layer wrapper around the shared `bindInterface`. Translates the
+/// string error to a typed `TracerouteError.interfaceBindFailed` and logs.
 internal func bindTraceInterface(
   sockfd: Int32, family: Int32, interfaceName: String, ifIndex: UInt32, enableLogging: Bool
 ) throws {
-  var index = ifIndex
-  let level = family == AF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP
-  let opt = family == AF_INET6 ? IPV6_BOUND_IF : IP_BOUND_IF
-  if setsockopt(sockfd, level, opt, &index, socklen_t(MemoryLayout<UInt32>.size)) != 0 {
+  if let errMsg = bindInterface(sockfd: sockfd, family: family, ifIndex: ifIndex) {
     let error = errno
     let details =
-      "Failed to bind socket to interface '\(interfaceName)' (index: \(ifIndex)). This may indicate: (1) Insufficient permissions, (2) Interface is not available for ICMP binding, (3) Interface doesn't support the operation."
+      "Failed to bind socket to interface '\(interfaceName)' (index: \(ifIndex)): \(errMsg). This may indicate: (1) Insufficient permissions, (2) Interface is not available for ICMP binding, (3) Interface doesn't support the operation."
     if enableLogging {
-      print("[SwiftFTR] ERROR: bind-to-interface failed - errno=\(error)")
+      print("[SwiftFTR] ERROR: bind-to-interface failed - \(errMsg)")
     }
     throw TracerouteError.interfaceBindFailed(
       interface: interfaceName, errno: error, details: details)
@@ -1138,55 +1094,14 @@ internal func bindTraceInterface(
   }
 }
 
-/// Family-aware source-IP bind. v4 → `sockaddr_in`; v6 → `sockaddr_in6` with
-/// optional link-local `%zone` suffix preserved via `parseIPv6Scoped`.
+/// Trace-layer wrapper around the shared `bindSourceIP`. Translates the string
+/// error to a typed `TracerouteError.sourceIPBindFailed` and logs.
 internal func bindTraceSourceIP(
   sockfd: Int32, family: Int32, sourceIP: String, enableLogging: Bool
 ) throws {
-  switch family {
-  case AF_INET:
-    var addr = sockaddr_in()
-    addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-    addr.sin_family = sa_family_t(AF_INET)
-    addr.sin_port = 0
-    if inet_pton(AF_INET, sourceIP, &addr.sin_addr) != 1 {
-      throw TracerouteError.sourceIPBindFailed(
-        sourceIP: sourceIP, errno: errno,
-        details: "Invalid IPv4 address '\(sourceIP)'.")
-    }
-    let rc = withUnsafePointer(to: &addr) { ptr in
-      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-        bind(sockfd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-      }
-    }
-    if rc != 0 {
-      throw TracerouteError.sourceIPBindFailed(
-        sourceIP: sourceIP, errno: errno, details: "bind() failed for v4 source IP")
-    }
-  case AF_INET6:
-    let (bare, scopeID) = parseIPv6Scoped(sourceIP)
-    var addr = sockaddr_in6()
-    addr.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
-    addr.sin6_family = sa_family_t(AF_INET6)
-    addr.sin6_scope_id = scopeID
-    if inet_pton(AF_INET6, bare, &addr.sin6_addr) != 1 {
-      throw TracerouteError.sourceIPBindFailed(
-        sourceIP: sourceIP, errno: errno,
-        details: "Invalid IPv6 address '\(sourceIP)'.")
-    }
-    let rc = withUnsafePointer(to: &addr) { ptr in
-      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-        bind(sockfd, $0, socklen_t(MemoryLayout<sockaddr_in6>.size))
-      }
-    }
-    if rc != 0 {
-      throw TracerouteError.sourceIPBindFailed(
-        sourceIP: sourceIP, errno: errno, details: "bind() failed for v6 source IP")
-    }
-  default:
+  if let errMsg = bindSourceIP(sockfd: sockfd, family: family, sourceIP: sourceIP) {
     throw TracerouteError.sourceIPBindFailed(
-      sourceIP: sourceIP, errno: 0,
-      details: "Unsupported family for source bind: \(family)")
+      sourceIP: sourceIP, errno: errno, details: errMsg)
   }
   if enableLogging {
     print("[SwiftFTR] Bound trace socket to source IP '\(sourceIP)'")

--- a/docs/IPV6.md
+++ b/docs/IPV6.md
@@ -58,9 +58,9 @@ Dual-stack `tcpProbe(...)` and `udpProbe(...)`: same entry points work for both 
 
 `STUN.swift` is now dual-stack via a family-parameterized core (`stunGetPublicIP(family:host:port:...)`) that resolves, sockets, binds, sends, and parses XOR-MAPPED-ADDRESS for both v4 (Family 0x01) and v6 (Family 0x02) per RFC 5389 §15.2 — including the v6-specific un-XOR of bytes 4..15 against the transaction ID. `STUNPublicIP` gained a `family` field; new `PublicIPs { v4, v6 }` struct and `public func getPublicIPs() async -> PublicIPs` run both families in parallel via `async let` and return whichever succeeded (never throws). v6 source-IP binding reuses the family-aware `bindProbeSourceIP` helper introduced in Stage 3. Back-compat shims for `stunGetPublicIPv4*` and `getPublicIPv4`; new `stunGetPublicIPv6*` companions added.
 
-### Stage 5 — Resolver consolidation
+### ~~Stage 5 — Resolver consolidation~~ *(shipped)*
 
-Pure refactor, no behavior change. Replace the 4 duplicated `resolveIPv4` / `resolveHostname` helpers (`Ping.swift`, `Traceroute.swift`, `TCPProbe.swift`, `UDPProbe.swift`) with one dual-stack helper in `Utils.swift` or a new `Hostname.swift`. Trivially-reviewable once every caller path is already v6-aware.
+`Hostname.swift` is now the single source of truth for: dual-stack `resolveHost(host:prefer:)`, family-aware `bindSourceIP(sockfd:family:sourceIP:)` (renamed from `bindProbeSourceIP`), and new `bindInterface(sockfd:family:ifIndex:)`. The old v4-only `resolveIPv4` in `Traceroute.swift` was deleted after `Multipath.swift` (the last caller) migrated to `resolveHost(host:, prefer: .v4)`. `bindTraceInterface` / `bindTraceSourceIP` became thin wrappers that translate the string-error contract to the typed `TracerouteError` cases trace callers expect. TCP, UDP, STUN all call the shared helpers directly.
 
 ### Stage 6 — `swift-ip2asn` 0.4.0 + IPv6 ASN labels
 


### PR DESCRIPTION
## Summary

Pure refactor; no behavior change, no public API change. Tidies up duplication that accumulated across Stages 1–4 now that every caller path is family-aware.

`Hostname.swift` is now the single source of truth for:
- the dual-stack `resolveHost(host:prefer:)` resolver (added Stage 2);
- the family-aware source-IP bind, renamed from `bindProbeSourceIP` to **`bindSourceIP`** (was Stage 3, now serves all socket paths);
- a new family-aware interface bind, **`bindInterface(sockfd:family:ifIndex:) -> String?`**, centralizing the `IP_BOUND_IF` (v4) / `IPV6_BOUND_IF` (v6) `setsockopt` call.

## What moved

| Before | After |
|---|---|
| `Traceroute.swift::resolveIPv4(host:enableLogging:) -> sockaddr_in` | **Deleted**. Last caller (`Multipath.swift`) migrated to `resolveHost(host:, prefer: .v4)`. |
| `Hostname.swift::bindProbeSourceIP` | Renamed → **`bindSourceIP`** (no longer probe-specific). |
| Inline interface binding in `TCPProbe.swift`, `STUN.swift` | Both now call the new **`bindInterface(sockfd:family:ifIndex:)`**. |
| `Traceroute.swift::bindTraceInterface`, `bindTraceSourceIP` | Now thin wrappers that delegate to the shared helpers and translate the `String?` error contract to typed `TracerouteError.{interfaceBindFailed,sourceIPBindFailed}` for trace's caller contract. |

`Multipath` stays v4-only by design (ECMP probing is heavily tied to IPv4 paris-traceroute / 5-tuple semantics) but now uses the shared resolver via `.v4` preference rather than its own helper.

## Verification

- [x] `swift format lint -r Sources Tests` — clean.
- [x] `swift build -c debug` and `-c release --product swift-ftr` — clean.
- [x] `PTR_SKIP_STUN=1 SKIP_NETWORK_TESTS=1 swift test` — all 167 unit tests pass.
- [x] Manual v4 trace regression: `swift-ftr 1.1.1.1` → same output (AS13335, 1 hop, ~13ms).
- [x] Manual v6 trace regression: `swift-ftr 2606:4700:4700::1111` → same output (AS13335 via WARP, 1 hop, ~11ms).
- [x] Manual v4 ping regression: `swift-ftr ping 1.1.1.1 -c 3` → 0% loss, ~7.7ms avg.
- [x] Manual v6 ping regression: `swift-ftr ping 2606:4700:4700::1111 -c 3` → 0% loss, ~7.4ms avg.

## Diff stats

```
7 files changed, 61 insertions(+), 119 deletions(-)
```

Net deletion of 58 lines — the consolidation removes more than it adds.

## What's left for v0.13.0

Per `docs/IPV6.md` the remaining work is hardening:
- **Stage 7**: v6-capable CI runner, NAT64 transparency, happy-eyeballs racing, v6 parser fuzzing, `VPNContext.vpnLocalIPs` population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)