### PR TITLE
fix(classifier): populate VPNContext.vpnLocalIPs from getifaddrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here. This project follows Se
 
 Unreleased (0.13.0-dev)
 -----------------------
+### Bug Fix
+
+**Populate `VPNContext.vpnLocalIPs` from `getifaddrs`**
+
+Pre-existing bug: `VPNContext.vpnLocalIPs: Set<String>` has been declared since the initial implementation but was always populated as an empty set by `VPNContext.forInterface(_:)`. Downstream consumers (NWX flagged this during the IPv6 review) relied on it to tag hops that land on a VPN local IP as `.vpn` rather than `.transit`, but the empty set meant the classifier silently fell through to ASN-based segmentation only.
+
+- `VPNContext.forInterface(_:)` now calls a new internal `discoverVPNLocalIPs()` that walks `getifaddrs` and collects every IPv4 and IPv6 address bound to an interface that `NetworkInterfaceDiscovery.isVPNInterface` matches (`utun*`, `ipsec*`, `ppp*`, `tun*`, `tap*`, `wg*`, `gpd*`, `ztun*`).
+- v6 link-local addresses keep their `%zone` suffix via the existing `ipv6String` helper so set entries match what the classifier sees from a parsed hop.
+- New `testVPNContextPopulatesLocalIPs` asserts the discovery returns valid v4/v6 strings and that calls with different VPN-shaped interface names yield the same set (since we walk every VPN interface on the host).
+- All 168 unit tests pass.
+
 ### Refactor
 
 **Resolver and bind-helper consolidation (Stage 5 of v6 parity — see [`docs/IPV6.md`](docs/IPV6.md))**

--- a/Sources/SwiftFTR/Segmentation.swift
+++ b/Sources/SwiftFTR/Segmentation.swift
@@ -108,6 +108,9 @@ public struct VPNContext: Sendable {
   ///
   /// If the interface name matches VPN patterns (utun*, ipsec*, ppp*),
   /// the context will be configured for VPN-aware classification.
+  /// `vpnLocalIPs` is populated with the v4 and v6 addresses of every VPN
+  /// interface detected on the host, so the classifier can tag hops that
+  /// land on a VPN local IP as `.vpn` rather than `.transit`.
   public static func forInterface(_ name: String?) -> VPNContext {
     guard let name = name else {
       return VPNContext()
@@ -116,8 +119,48 @@ public struct VPNContext: Sendable {
     return VPNContext(
       traceInterface: name,
       isVPNTrace: isVPN,
-      vpnLocalIPs: []
-    )
+      vpnLocalIPs: discoverVPNLocalIPs())
+  }
+
+  /// Walks `getifaddrs` and collects every v4 and v6 address bound to an
+  /// interface whose name matches `NetworkInterfaceDiscovery.isVPNInterface`.
+  /// Used to populate `VPNContext.vpnLocalIPs` so the classifier can map a
+  /// trace hop's IP back to the VPN side of a split tunnel. Both families
+  /// are included — on dual-stack-source / v4-only-tunnel setups, the v6
+  /// addresses on the physical interface are NOT in this set (correct
+  /// behavior; the v6 trace doesn't go through the VPN).
+  ///
+  /// Returns an empty set on platforms without `getifaddrs` or on error.
+  internal static func discoverVPNLocalIPs() -> Set<String> {
+    #if canImport(Darwin)
+      var ifaddrsPtr: UnsafeMutablePointer<ifaddrs>?
+      guard getifaddrs(&ifaddrsPtr) == 0, let first = ifaddrsPtr else {
+        return []
+      }
+      defer { freeifaddrs(ifaddrsPtr) }
+
+      var ips: Set<String> = []
+      var cursor: UnsafeMutablePointer<ifaddrs>? = first
+      while let addr = cursor {
+        defer { cursor = addr.pointee.ifa_next }
+        let name = String(cString: addr.pointee.ifa_name)
+        guard NetworkInterfaceDiscovery.isVPNInterface(name) else { continue }
+        guard let sa = addr.pointee.ifa_addr else { continue }
+        let family = Int32(sa.pointee.sa_family)
+        if family == AF_INET {
+          let sin = sa.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
+          ips.insert(ipString(sin))
+        } else if family == AF_INET6 {
+          let sin6 = sa.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee }
+          // Preserve `%zone` suffix for link-local addresses so the set
+          // entries match what the classifier sees from a parsed hop.
+          ips.insert(ipv6String(sin6.sin6_addr, scopeID: sin6.sin6_scope_id))
+        }
+      }
+      return ips
+    #else
+      return []
+    #endif
   }
 }
 

--- a/Tests/SwiftFTRTests/VPNClassificationTests.swift
+++ b/Tests/SwiftFTRTests/VPNClassificationTests.swift
@@ -32,6 +32,42 @@ struct VPNClassificationTests {
     #expect(nilContext.traceInterface == nil)
   }
 
+  /// `VPNContext.forInterface(_:)` now populates `vpnLocalIPs` by walking
+  /// `getifaddrs` and collecting every v4 and v6 address bound to an
+  /// interface that `NetworkInterfaceDiscovery.isVPNInterface` matches.
+  /// This test asserts the discovery doesn't crash and returns *something
+  /// shaped right*: any host running this test likely has at least one
+  /// `utun*` interface (Apple system services use them even without an
+  /// active VPN), so the set is usually non-empty — but we don't fail
+  /// if it is, because CI runners can be configured without them.
+  @Test("VPNContext.forInterface populates vpnLocalIPs from getifaddrs")
+  func testVPNContextPopulatesLocalIPs() {
+    let ctx = VPNContext.forInterface("utun0")
+    // Every entry should look like a valid IPv4 or IPv6 string.
+    for ip in ctx.vpnLocalIPs {
+      let isV4 = detectAddressFamily(ip) == AF_INET
+      // Strip %zone for v6 family check.
+      let bare = ip.split(separator: "%", maxSplits: 1).first.map(String.init) ?? ip
+      let isV6 = detectAddressFamily(bare) == AF_INET6
+      #expect(isV4 || isV6, "Each vpnLocalIPs entry should be a valid v4 or v6 string: \(ip)")
+    }
+    // Same set is returned regardless of the specific interface argument;
+    // the population walks every VPN interface on the host, not just the
+    // named one. Sanity check that calling twice with different VPN-shaped
+    // names yields the same set.
+    let ctx2 = VPNContext.forInterface("utun1")
+    #expect(ctx.vpnLocalIPs == ctx2.vpnLocalIPs)
+    // And a non-VPN interface produces no context at all (empty set is fine).
+    let wifiCtx = VPNContext.forInterface("en0")
+    // For a non-VPN interface, vpnLocalIPs reflects the host's other VPN
+    // interfaces (still useful — the classifier needs them to recognize
+    // VPN hops in a split-tunnel trace going out en0).
+    for ip in wifiCtx.vpnLocalIPs {
+      let bare = ip.split(separator: "%", maxSplits: 1).first.map(String.init) ?? ip
+      #expect(detectAddressFamily(bare) == AF_INET || detectAddressFamily(bare) == AF_INET6)
+    }
+  }
+
   // MARK: - HopCategory Tests
 
   @Test("VPN HopCategory exists")


### PR DESCRIPTION
## Summary

Pre-existing bug: `VPNContext.vpnLocalIPs: Set<String>` has been declared since the initial implementation but was always populated as an empty set by `VPNContext.forInterface(_:)`. Downstream consumers (NWX flagged this during the IPv6 review) relied on it to tag hops that land on a VPN local IP as `.vpn` rather than `.transit`, but the empty set meant the classifier silently fell through to ASN-based segmentation only.

## Fix

`VPNContext.forInterface(_:)` now calls a new internal `discoverVPNLocalIPs()` that walks `getifaddrs` and collects every IPv4 and IPv6 address bound to an interface that `NetworkInterfaceDiscovery.isVPNInterface` matches (`utun*`, `ipsec*`, `ppp*`, `tun*`, `tap*`, `wg*`, `gpd*`, `ztun*`).

- v6 link-local addresses keep their `%zone` suffix via the existing `ipv6String` helper so set entries match what the classifier sees from a parsed hop.
- Both families are collected, so a split-tunnel trace where en0 is dual-stack but the utun is v4-only correctly distinguishes "hop is on the VPN's v4 side" from "hop is on en0's v6 side."

## Tests

- New `testVPNContextPopulatesLocalIPs` asserts the discovery returns valid v4/v6 strings (validated via `detectAddressFamily`) and that calls with different VPN-shaped interface names yield the same set (we walk every VPN interface on the host, not just the named one).
- All **168** unit tests pass.

## Test plan

- [x] `swift format lint -r Sources Tests` — clean.
- [x] `swift build -c debug` — clean.
- [x] `PTR_SKIP_STUN=1 SKIP_NETWORK_TESTS=1 swift test` — 168 tests pass.
- [x] Manually verified on this host: 10+ utun* interfaces are detected and their addresses populate the set.
- [ ] Reviewer: confirm classifier behavior changes on a real split-tunnel trace where hops fall on VPN local IPs (NWX's `SplitTunnelManager` test path is the canonical reproduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)