### PR TITLE
feat(resolver): NAT64 transparency for v4 literals on v6-only networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here. This project follows Se
 
 Unreleased (0.13.0-dev)
 -----------------------
+### Features
+
+**NAT64 transparency for IPv4 literals on v6-only networks**
+
+In `.auto` mode (the default), v4 literals like `"1.1.1.1"` now go through `getaddrinfo` with `AI_V4MAPPED | AI_ADDRCONFIG` flags rather than the previous `inet_pton` fast path. macOS's resolver synthesizes a v4-mapped v6 address (typically under `64:ff9b::/96` per RFC 6147) when the system has detected a DNS64/NAT64 network — so `tracer.ping("1.1.1.1")` on a v6-only cellular network now "just works" via the gateway's translator rather than failing with `EHOSTUNREACH`.
+
+- Behavior on dual-stack networks is unchanged: `getaddrinfo` returns the v4 entry directly because v4 is locally routable.
+- Behavior on v6-only NAT64 networks: `getaddrinfo` returns the synthesized v6 address, the v6 socket is used transparently, and the trace/probe completes.
+- Force modes (`.v4` and `.v6`) keep the `inet_pton` fast path for literals — users that explicitly pinned a family opted out of NAT64 synthesis.
+- Cross-family literal rejection still throws (`.v4` against a v6 literal, `.v6` against a v4 literal) — preserved tests confirm.
+- Matches Apple's [SupportingIPv6DNS64NAT64](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/SupportingIPv6DNS64NAT64/SupportingIPv6DNS64NAT64.html) guidance for IPv6-compatible apps.
+
+Verified end-to-end on a dual-stack host: `swift-ftr ping 1.1.1.1` still resolves to `1.1.1.1` and pings v4; `swift-ftr ping 2606:4700:4700::1111` pings v6; `swift-ftr ping cloudflare.com` picks v6 (system-preferred address per RFC 6724). All 168 unit tests pass.
+
 ### Bug Fix
 
 **Populate `VPNContext.vpnLocalIPs` from `getifaddrs`**

--- a/Sources/SwiftFTR/Hostname.swift
+++ b/Sources/SwiftFTR/Hostname.swift
@@ -103,13 +103,21 @@ internal func bindInterface(sockfd: Int32, family: Int32, ifIndex: UInt32) -> St
 /// `UDPProbe.swift` is Stage 5 in `docs/IPV6.md`; this is the smaller extraction
 /// that unblocks Stage 2 traceroute.
 internal func resolveHost(host: String, prefer: PreferredFamily) throws -> ResolvedHost {
-  // Numeric literal fast path.
   let detected = detectAddressFamily(host)
-  if detected == AF_INET {
-    if prefer == .v6 {
-      throw TracerouteError.resolutionFailed(
-        host: host, details: "Preferred family v6 but literal is v4")
-    }
+
+  // Force-mode fast paths: when the caller explicitly asked for v4 or v6, skip
+  // getaddrinfo and use the literal directly. This preserves the original
+  // behavior for callers that know their family and want microsecond resolution.
+  //
+  // In `.auto` mode we always go through getaddrinfo (even for literals) so
+  // macOS's resolver can synthesize a v4-mapped v6 address for v4 literals on
+  // NAT64 networks (RFC 6147 / Apple's CLAT). On dual-stack networks the
+  // resolver returns the v4 literal unchanged; on v6-only NAT64 networks it
+  // returns the synthesized v6 address and the trace/probe goes via v6
+  // transparently — no caller code changes required. The extra getaddrinfo
+  // call costs ~tens of microseconds; the NAT64 transparency it buys is worth
+  // it (matches Apple's own guidance for IPv6-compatible apps).
+  if prefer == .v4 && detected == AF_INET {
     var sin = sockaddr_in()
     sin.sin_family = sa_family_t(AF_INET)
     sin.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
@@ -124,11 +132,7 @@ internal func resolveHost(host: String, prefer: PreferredFamily) throws -> Resol
       family: AF_INET, address: storage,
       addressLen: socklen_t(MemoryLayout<sockaddr_in>.size), canonical: ipString(sin))
   }
-  if detected == AF_INET6 {
-    if prefer == .v4 {
-      throw TracerouteError.resolutionFailed(
-        host: host, details: "Preferred family v4 but literal is v6")
-    }
+  if prefer == .v6 && detected == AF_INET6 {
     let (bare, scopeID) = parseIPv6Scoped(host)
     var sin6 = sockaddr_in6()
     sin6.sin6_family = sa_family_t(AF_INET6)
@@ -146,11 +150,25 @@ internal func resolveHost(host: String, prefer: PreferredFamily) throws -> Resol
       addressLen: socklen_t(MemoryLayout<sockaddr_in6>.size),
       canonical: ipv6String(sin6.sin6_addr, scopeID: scopeID))
   }
+  // Mismatched literal vs preferred family throws.
+  if prefer == .v4 && detected == AF_INET6 {
+    throw TracerouteError.resolutionFailed(
+      host: host, details: "Preferred family v4 but literal is v6")
+  }
+  if prefer == .v6 && detected == AF_INET {
+    throw TracerouteError.resolutionFailed(
+      host: host, details: "Preferred family v6 but literal is v4")
+  }
 
-  // Hostname path — let getaddrinfo do dual-stack lookup; pick the first answer
-  // that matches `prefer` (or any if .auto).
+  // `.auto` mode (and any hostname path) — let getaddrinfo handle everything,
+  // including NAT64 synthesis for v4 literals on v6-only networks. The
+  // `AI_V4MAPPED | AI_ADDRCONFIG | AI_DEFAULT` flag set tells Darwin's resolver
+  // to synthesize a v4-mapped v6 address when only v6 is configured locally.
   var hints = addrinfo()
   hints.ai_socktype = SOCK_DGRAM
+  // AI_DEFAULT == AI_V4MAPPED | AI_ADDRCONFIG. Hardcoded numeric form below
+  // because AI_DEFAULT isn't exposed in all Swift overlay versions.
+  hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG
   switch prefer {
   case .v4: hints.ai_family = AF_INET
   case .v6: hints.ai_family = AF_INET6

--- a/docs/IPV6.md
+++ b/docs/IPV6.md
@@ -105,7 +105,7 @@ To exercise the v6 paths in CI:
 
 ## Known limitations & open questions
 
-- **NAT64 transparency** (Stage 7): `ping(to: "1.1.1.1")` on a pure-v6 network with DNS64/NAT64 should "just work" via the gateway's synthesized v6 address (typically under `64:ff9b::/96`). Stage 1 doesn't implement this — a v4 literal is treated as v4 and creates a v4 socket. Workaround: pass the hostname, not the literal. The `getaddrinfo(AF_UNSPEC)` path will return the NAT64-synthesized v6 address transparently.
+- ~~**NAT64 transparency**: `ping(to: "1.1.1.1")` on a pure-v6 network with DNS64/NAT64~~ *(shipped)*. In `.auto` mode (the default), v4 literals go through `getaddrinfo` with `AI_V4MAPPED | AI_ADDRCONFIG` flags so macOS synthesizes a v4-mapped v6 address when on a v6-only NAT64 network. Force modes (`.v4` / `.v6`) keep the `inet_pton` fast path. Dual-stack hosts see unchanged behavior.
 - **Happy-eyeballs**: `.auto` for hostnames currently takes the first `getaddrinfo` answer without racing v4 and v6 connects. RFC 8305 happy-eyeballs is deferred — most callers either pin a family (`.v4` / `.v6`) or accept the OS's resolver preference.
 - **Should the `ttl` field on `PingResponse` become `hopCount` (or split into a separate `hopLimit`)?** Currently overloaded: v4 TTL or v6 hop limit. Documented dual meaning. Splitting would be source-breaking; revisit only if it causes real consumer confusion.
 


### PR DESCRIPTION
## Summary

`tracer.ping(\"1.1.1.1\")` on a v6-only cellular network now \"just works\" via the gateway's NAT64 translator (typically `64:ff9b::/96` per RFC 6147) rather than failing with `EHOSTUNREACH`. Downstream consumers on T-Mobile-style v6-only setups have flagged this as a real gap.

## Fix

In `.auto` mode (the default), v4 literals now go through `getaddrinfo` with `AI_V4MAPPED | AI_ADDRCONFIG` flags rather than the previous `inet_pton` fast path. macOS's resolver synthesizes a v4-mapped v6 address when the system has detected a DNS64/NAT64 network. The synthesis is transparent: callers pass `\"1.1.1.1\"`, the v6 socket is used under the hood, the trace/probe completes.

| Network | `.auto` + v4 literal | Result |
|---|---|---|
| Dual-stack | `getaddrinfo` returns v4 | unchanged — v4 socket, v4 trace |
| v6-only NAT64 | `getaddrinfo` synthesizes v6 | **new** — v6 socket, transparent NAT64 |
| `.v4` or `.v6` force | `inet_pton` fast path | unchanged — explicit family wins |

## What's preserved

- Force modes (`.v4` / `.v6`) keep the `inet_pton` fast path — users that explicitly pinned a family opted out of NAT64 synthesis.
- Cross-family literal rejection still throws (`.v4` against a v6 literal, `.v6` against a v4 literal). Verified by the existing `testPreferredV4RejectsV6Literal` / `testPreferredV6RejectsV4Literal` tests.
- Dual-stack hosts see byte-identical behavior to pre-PR.

## Verified end-to-end (dual-stack host)

| Command | resolvedIP | family |
|---|---|---|
| `swift-ftr ping 1.1.1.1` | `1.1.1.1` | v4 |
| `swift-ftr ping 2606:4700:4700::1111` | `2606:4700:4700::1111` | v6 |
| `swift-ftr ping cloudflare.com` | `2606:4700::6810:84e5` | v6 (system-preferred per RFC 6724) |

All three pings succeed; behavior is unchanged from pre-PR.

## Cost

The extra `getaddrinfo` call costs ~tens of microseconds on the literal fast path. For an operation that takes hundreds of milliseconds end-to-end (any network probe), this is negligible — matches Apple's [SupportingIPv6DNS64NAT64](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/SupportingIPv6DNS64NAT64/SupportingIPv6DNS64NAT64.html) guidance for IPv6-compatible apps.

## What I couldn't test locally

This dual-stack host can't exercise the actual NAT64 synthesis path. The code change is correct per Apple's documentation and the macOS `getaddrinfo` behavior with `AI_V4MAPPED | AI_ADDRCONFIG` is well-specified. A downstream consumer on a v6-only network should see `swift-ftr ping 1.1.1.1` start working where it previously failed.

## Test plan

- [x] `swift format lint -r Sources Tests` — clean.
- [x] `swift build -c debug` and `-c release --product swift-ftr` — clean.
- [x] `PTR_SKIP_STUN=1 SKIP_NETWORK_TESTS=1 swift test` — 168 tests pass.
- [x] Manual dual-stack verification (table above).
- [x] Existing `PreferredFamily` cross-family rejection tests pass.
- [ ] Reviewer / NWX: confirm `tracer.ping(\"1.1.1.1\")` works on a v6-only T-Mobile-style network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)